### PR TITLE
[ID-27] Content length header missing when signing request

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -128,10 +128,10 @@
         "filename": "sigauth/signature_test.go",
         "hashed_secret": "560d8afec04521a86978c49f5b05961e40fd6a35",
         "is_verified": false,
-        "line_number": 346,
+        "line_number": 347,
         "is_secret": false
       }
     ]
   },
-  "generated_at": "2021-12-03T17:54:45Z"
+  "generated_at": "2021-12-30T16:16:23Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Content length header missing when signing request [#27](https://github.com/rokwire/core-auth-library-go/issues/27)
 
 ## [1.0.5] - 2021-12-21
 ### Added

--- a/example/signature/app.go
+++ b/example/signature/app.go
@@ -16,13 +16,13 @@ package main
 
 import (
 	"bytes"
-	"crypto/rsa"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
 
 	"github.com/rokwire/core-auth-library-go/authservice"
+	"github.com/rokwire/core-auth-library-go/internal/testutils"
 	"github.com/rokwire/core-auth-library-go/sigauth"
 	"github.com/rokwire/logging-library-go/logs"
 )
@@ -64,9 +64,10 @@ func (we WebAdapter) sampleSignedRequest(url string, param string, body string) 
 		return "", fmt.Errorf("error formatting sample request: %v", err)
 	}
 
-	q := req.URL.Query()
-	q.Add("param", param)
-	req.URL.RawQuery = q.Encode()
+	// q := req.URL.Query()
+	// q.Add("param", param)
+	// req.URL.RawQuery = q.Encode()
+	req.Header.Set("Content-Type", "application/json")
 
 	err = we.signatureAuth.SignRequest(req)
 	if err != nil {
@@ -122,13 +123,12 @@ func NewWebAdapter(signatureAuth *sigauth.SignatureAuth) WebAdapter {
 func main() {
 	// Define list of services to load public keys for. For signature auth, this includes all services
 	// 	that this service will receive signed requests from.
-	services := []string{"example2"}
+	services := []string{}
 	// Instantiate a remote AuthDataLoader to load service registration records from auth service
 	config := authservice.RemoteAuthDataLoaderConfig{
-		AuthServicesHost: "https://auth.rokwire.com/services",
-		ServiceToken:     "sample_token",
-
-		DeletedAccountsCallback: printDeletedAccountIDs,
+		AuthServicesHost: "http://localhost/core",
+		// ServiceToken:     "sample_token",
+		// DeletedAccountsCallback: printDeletedAccountIDs,
 	}
 	logger := logs.NewLogger("example", nil)
 	dataLoader, err := authservice.NewRemoteAuthDataLoader(config, services, logger)
@@ -137,28 +137,29 @@ func main() {
 	}
 
 	// Instantiate AuthService instance
-	authService, err := authservice.NewAuthService("example", "https://sample.rokwire.com", dataLoader)
+	authService, err := authservice.NewAuthService("example", "http://localhost:8080", dataLoader)
 	if err != nil {
 		log.Fatalf("Error initializing auth service: %v", err)
 	}
 
-	privKey := &rsa.PrivateKey{}
+	privKey := testutils.GetSamplePrivKey()
 
 	// TODO: Load service private key
 
 	// Instantiate SignatureAuth instance to perform token validation
-	signatureAuth, err := sigauth.NewSignatureAuth(privKey, authService)
+	signatureAuth, err := sigauth.NewSignatureAuth(privKey, authService, true)
 	if err != nil {
 		log.Fatalf("Error initializing signature auth: %v", err)
 	}
 
 	// Instantiate and start a new WebAdapter
 	adapter := NewWebAdapter(signatureAuth)
-	adapter.Start()
 
 	// Tip: You do not need to subscribe to services you are making requests to, only those
 	// 		that you are receiving requests from
-	response, err := adapter.sampleSignedRequest("https://example3.rokwire.com", "sample", "This is an sample body")
+
+	fmt.Println("adapter done")
+	response, err := adapter.sampleSignedRequest("http://localhost/core/tps/account/token", "sample", "{\"auth_type\":\"signature\",\"creds\":{\"id\":\"072da518-68ee-11ec-b78b-00ffd2760de8\"}}")
 	if err != nil {
 		log.Printf("Error making sample signed request: %v", err)
 	} else {

--- a/sigauth/signature_test.go
+++ b/sigauth/signature_test.go
@@ -38,7 +38,7 @@ func setupTestSignatureAuth(mockLoader *mocks.AuthDataLoader) (*sigauth.Signatur
 	if err != nil {
 		return nil, fmt.Errorf("error setting up test auth service: %v", err)
 	}
-	return sigauth.NewSignatureAuth(testutils.GetSamplePrivKey(), auth)
+	return sigauth.NewSignatureAuth(testutils.GetSamplePrivKey(), auth, true)
 }
 
 func setupTestSignatureAuthWithPrivKey(mockLoader *mocks.AuthDataLoader, privKey *rsa.PrivateKey) (*sigauth.SignatureAuth, error) {
@@ -50,7 +50,7 @@ func setupTestSignatureAuthWithPrivKey(mockLoader *mocks.AuthDataLoader, privKey
 	if err != nil {
 		return nil, fmt.Errorf("error setting up test auth service: %v", err)
 	}
-	return sigauth.NewSignatureAuth(privKey, auth)
+	return sigauth.NewSignatureAuth(privKey, auth, true)
 }
 
 func TestSignatureAuth_CheckServiceSignature(t *testing.T) {
@@ -338,24 +338,25 @@ func TestGetRequestDigest(t *testing.T) {
 		r *http.Request
 	}
 	tests := []struct {
-		name    string
-		args    args
-		want    string
-		wantErr bool
+		name       string
+		args       args
+		wantDigest string
+		wantLength int
+		wantErr    bool
 	}{
-		{name: "success", args: args{r: testReq}, want: "SHA-256=OEbyxI+bLFvC3nD0cs4BcWAabvZsLFUdK1GBQrbyrzk=", wantErr: false},
-		{name: "nil_request", args: args{r: nil}, want: "", wantErr: true},
-		{name: "empty_body", args: args{r: testEmptyBody}, want: "", wantErr: false},
+		{name: "success", args: args{r: testReq}, wantDigest: "SHA-256=OEbyxI+bLFvC3nD0cs4BcWAabvZsLFUdK1GBQrbyrzk=", wantLength: len(data), wantErr: false},
+		{name: "nil_request", args: args{r: nil}, wantDigest: "", wantLength: 0, wantErr: true},
+		{name: "empty_body", args: args{r: testEmptyBody}, wantDigest: "", wantLength: 0, wantErr: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := sigauth.GetRequestDigest(tt.args.r)
+			gotDigest, gotLength, err := sigauth.GetRequestDigest(tt.args.r)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetRequestDigest() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if got != tt.want {
-				t.Errorf("GetRequestDigest() = %v, want %v", got, tt.want)
+			if gotDigest != tt.wantDigest || gotLength != tt.wantLength {
+				t.Errorf("GetRequestDigest() = %v, %v, want %v, %v", gotDigest, gotLength, tt.wantDigest, tt.wantLength)
 			}
 		})
 	}


### PR DESCRIPTION
## Description
Set "Content-Length" header before computing signature string when signing a request. 

**Resolves #27**

[comment]: # (This project only accepts pull requests related to open issues.)
[comment]: # (If suggesting a new feature or change, please discuss it in an issue first.)
[comment]: # (If fixing a bug, there should be an issue describing it with steps to reproduce.)

## Review Time Estimate
_Please give your idea of how soon this pull request needs to be reviewed by selecting one of the options below. This can be based on the criticality of the issue at hand and/or other relevant factors._

[comment]: # (To select an option, please put an 'x' in the applicable box.)
[comment]: # (If you're unsure about any of these, don't hesitate to ask. We're here to help!.)

- [ ] Immediately
- [ ] Within a week
- [x] When possible

## Type of changes
_Please select a relevant option:_

[comment]: # (To select an option, please put an 'x' in the applicable box.)
[comment]: # (If you're unsure about any of these, don't hesitate to ask. We're here to help!.)

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Other (any another change that does not fall in one of the above categories.)

## Checklist:
_Please select all applicable options:_

[comment]: # (To select your options, please put an 'x' in the all boxes that apply.)
[comment]: # (If you're unsure about any of these, don't hesitate to ask. We're here to help!.)

- [x] I have signed the Rokwire Contributor License Agreement ([CLA](https://rokwire.org/rokwire_cla)). (_Any contributor who is not an employee of the University of Illinois whose official duties include contributing to the Rokwire software, or who is not paid by the Rokwire project, needs to sign the CLA before their contribution can be accepted._)
- [x] I have updated the [CHANGELOG](../CHANGELOG.md).
- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] My change requires updating the documentation.
- [ ] I have made necessary changes to the documentation.
- [x] I have added tests related to my changes.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.

---

[comment]: # (Template credit: This pull request template is based on Embedded Artistry {https://github.com/embeddedartistry/templates/blob/master/.github/PULL_REQUEST_TEMPLATE.md}, Clowder {https://github.com/clowder-framework/clowder/blob/develop/.github/PULL_REQUEST_TEMPLATE.md}, and TalAter {https://github.com/TalAter/open-source-templates} templates.)
